### PR TITLE
Encode dates as GMT and make sure the ISO-8601 string has a Z indicating UTC

### DIFF
--- a/WPXMLRPC/WPXMLRPCEncoder.m
+++ b/WPXMLRPC/WPXMLRPCEncoder.m
@@ -283,8 +283,10 @@
 
 - (void)encodeDate:(NSDate *)date {
     unsigned components = kCFCalendarUnitYear | kCFCalendarUnitMonth | kCFCalendarUnitDay | kCFCalendarUnitHour | kCFCalendarUnitMinute | kCFCalendarUnitSecond;
-    NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:components fromDate:date];
-    NSString *buffer = [NSString stringWithFormat:@"%.4ld%.2d%.2dT%.2d:%.2ld:%.2ld", (long)[dateComponents year], (int)[dateComponents month], (int)[dateComponents day], (int)[dateComponents hour], (long)[dateComponents minute], (long)[dateComponents second], nil];
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    [calendar setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
+    NSDateComponents *dateComponents = [calendar components:components fromDate:date];
+    NSString *buffer = [NSString stringWithFormat:@"%.4ld%.2d%.2dT%.2d:%.2ld:%.2ld%@", (long)[dateComponents year], (int)[dateComponents month], (int)[dateComponents day], (int)[dateComponents hour], (long)[dateComponents minute], (long)[dateComponents second], @"Z", nil];
     
     [self valueTag:@"dateTime.iso8601" value:buffer];
 }


### PR DESCRIPTION
Fixes #6 

Relates to #2 
