### PR TITLE
Safety when a nil parameter is received to prevent exception throwing

### DIFF
--- a/WPXMLRPC/WPStringUtils.m
+++ b/WPXMLRPC/WPStringUtils.m
@@ -26,8 +26,12 @@
 @implementation WPStringUtils
 
 + (NSString *)unescapedStringWithString:(NSString *)aString {
+    if (!aString) {
+        return nil;
+    }
+    
     NSMutableString *string = [NSMutableString stringWithString:aString];
-
+    
     [string replaceOccurrencesOfString:@"&quot;" withString:@"\"" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@"&#x27;" withString:@"'" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@"&#x39;" withString:@"'" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
@@ -36,19 +40,23 @@
     [string replaceOccurrencesOfString:@"&gt;" withString:@">" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@"&lt;" withString:@"<" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@"&amp;"  withString:@"&" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
-
+    
     return [NSString stringWithString:string];
 }
 
 + (NSString *)escapedStringWithString:(NSString *)aString {
+    if (!aString) {
+        return nil;
+    }
+    
     NSMutableString *string = [NSMutableString stringWithString:aString];
-
+    
     // NOTE:we use unicode entities instead of &amp; &gt; &lt; etc. since some hosts (powweb, fatcow, and similar)
     // have a weird PHP/libxml2 combination that ignores regular entities
     [string replaceOccurrencesOfString:@"&"  withString:@"&#38;" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@">"  withString:@"&#62;" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
     [string replaceOccurrencesOfString:@"<"  withString:@"&#60;" options:NSLiteralSearch range:NSMakeRange(0, [string length])];
-
+    
     return [NSString stringWithString:string];
 }
 


### PR DESCRIPTION
Fixes #8 

Related: https://github.com/wordpress-mobile/WordPress-iOS/issues/1448
