### PR TITLE
Increase Minimum iOS Deployment to 9.0 for Xcode 12

### DIFF
--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.public_header_files = [ 'WPXMLRPC/WPXMLRPC.h', 'WPXMLRPC/WPXMLRPCEncoder.h', 'WPXMLRPC/WPXMLRPCDecoder.h' ]
   s.libraries    = 'iconv'
   s.requires_arc = true
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.7'
   s.tvos.deployment_target = '9.0'
 end

--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "wpxmlrpc"
-  s.version      = "0.8.5"
+  s.version      = "0.9.0-beta.1"
   s.summary      = "Lightweight XML-RPC library."
   s.homepage     = "https://github.com/wordpress-mobile/wpxmlrpc"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }

--- a/wpxmlrpc.xcodeproj/project.pbxproj
+++ b/wpxmlrpc.xcodeproj/project.pbxproj
@@ -1109,7 +1109,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Support/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1164,7 +1164,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Support/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.wpxmlrpc;


### PR DESCRIPTION
Hi! 👋 Please reject this PR if this is not the right way to approach this. 

## Problem

This library is a deep dependency of [woocommerce-ios](https://github.com/woocommerce/woocommerce-ios). Compiling WCiOS with Xcode 12 results in so many problems. One of which has already been fixed by @jkmassel in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/284. The rest are just warnings:

<img width="400" alt="xmlrpc" src="https://user-images.githubusercontent.com/198826/93797612-b3c9d980-fbf9-11ea-9bda-7c5fa685f9cf.png">
 
## Solution

It looks like these warnings can be fixed by [a workaround in `Podfile`](https://www.jessesquires.com/blog/2020/07/20/xcode-12-drops-support-for-ios-8-fix-for-cocoapods/). But since we can also probably (?) fix it by upgrading the minimum iOS version in this library, I went with that for this one. 

The iOS minimum deployment target was changed to 9.0. Please let me know if it should be higher. 

Changing the deployment target is enough to remove the build warning. 

## Testing 

- Please confirm that the build passes. 
- I have also verified that the project still compiles for Xcode 11