### PR TITLE
Fix warnings

### DIFF
--- a/WPXMLRPC/WPBase64Utils.m
+++ b/WPXMLRPC/WPBase64Utils.m
@@ -96,7 +96,7 @@ static unsigned char base64DecodeLookup[256] =
 // returns the decoded buffer. Must be free'd by caller. Length is given by
 //	outputLength.
 //
-void *NewBase64Decode(
+static void *NewBase64Decode(
                       const char *inputBuffer,
                       size_t length,
                       size_t *outputLength)
@@ -174,7 +174,7 @@ void *NewBase64Decode(
 // returns the encoded buffer. Must be free'd by caller. Length is given by
 //	outputLength.
 //
-char *NewBase64Encode(
+static char *NewBase64Encode(
                       const void *buffer,
                       size_t length,
                       bool separateLines,


### PR DESCRIPTION
Hi!

When integrating the files into our project, two warnings appeared in WPBase64Utils. 