### PR TITLE
Add `CHANGELOG.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+
+---
+
+- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,4 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Added this changelog file [#67]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+The format of this document is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- This is a comment, you won't see it when GitHub renders the Markdown file.
+
+When releasing a new version:
+
+1. Remove any empty section (those with `_None._`)
+2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/wpxmlrpc/releases/tag/<version_number>)`
+3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
+
+## Unreleased
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+-->
+
+## Unreleased
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._


### PR DESCRIPTION
_Looking at #66, I noticed I had missed this repo when working on the `CHANGELOG.md` introduction across our libs._

Adds `CHANGELOG.md`. Based on https://github.com/wordpress-mobile/WordPressKit-iOS/pull/545 and the PR template iteration from https://github.com/wordpress-mobile/WordPressUI-iOS/pull/119.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.