### PR TITLE
Use Xcode 14.1 in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#2.10.0: ~
+  - &bash_cache automattic/bash-cache#2.10.0
   env: &common_env
     IMAGE_ID: xcode-14.1
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   plugins: &common_plugins
   - &bash_cache automattic/bash-cache#2.10.0: ~
   env: &common_env
-    IMAGE_ID: xcode-14.0.1
+    IMAGE_ID: xcode-14.1
 
 # This is the default pipeline – it will build and test the pod
 steps:


### PR DESCRIPTION
While reviewing #66, I noticed CI was using Xcode 14.0.1. This updates to using the latest version.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
