### PR TITLE
Use the same iOS deployment target between SPM and CocoaPods

### DIFF
--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
 
   s.ios.deployment_target = '11.0'
-  s.osx.deployment_target = '10.7'
+  s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '9.0'
   s.swift_version = '5.0'
 

--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '9.0'
+  s.tvos.deployment_target = '11.0'
   s.swift_version = '5.0'
 
   s.source        = { git: 'https://github.com/wordpress-mobile/wpxmlrpc.git', tag: s.version.to_s }

--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.license       = { type: 'MIT', file: 'LICENSE.md' }
   s.author        = { 'The WordPress Mobile Team' => 'mobile@wordpress.org' }
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.7'
   s.tvos.deployment_target = '9.0'
   s.swift_version = '5.0'


### PR DESCRIPTION
Noticed this while looking at https://github.com/wordpress-mobile/WordPressKit-iOS/pull/553 and saw warnings in Xcode

![image](https://user-images.githubusercontent.com/1218433/205605530-568ff80d-2208-4ab1-8007-c430d71cda0e.png)

It won't be an issue much longer since we'll move to fetch this via SPM, and to address it we'd also have to ship a new version. Still, it's good to be consisent.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
