### PR TITLE
Bump version from 0.9.0 to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,21 @@ _None._
 
 ### New Features
 
-- Add Swift Package Manager support [#66]
+_None._
 
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## [0.10.0](https://github.com/wordpress-mobile/wpxmlrpc/releases/tag/0.10.0)
+
+### New Features
+
+- Add Swift Package Manager support [#66]
 
 ### Internal Changes
 

--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'wpxmlrpc'
-  s.version       = '0.9.0'
+  s.version       = '0.10.0'
 
   s.summary       = 'Lightweight XML-RPC library.'
   s.description   = <<-DESC


### PR DESCRIPTION
In https://github.com/wordpress-mobile/wpxmlrpc/pull/70 I mentioned that we might want to ship a new version of the library.

Here's the new version, just in case.

I decided to spend the ten minutes required to go through the process because, while we're actively adding support for SPM to our libraries, we are yet to start migrating away from CocoaPods as the dependency manager in the client apps that rely on it. Therefore, it makes sense to me to have the most up-to-date possible setup available in CocoaPods.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
