### PR TITLE
Remove tvOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- Remove tvOS support [#77]
 
 ### New Features
 

--- a/wpxmlrpc.podspec
+++ b/wpxmlrpc.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.13'
-  s.tvos.deployment_target = '11.0'
   s.swift_version = '5.0'
 
   s.source        = { git: 'https://github.com/wordpress-mobile/wpxmlrpc.git', tag: s.version.to_s }


### PR DESCRIPTION
None of our client needs it and supporting it at the CocoaPods level requires additional infrastructure that we find hard to justify having.

Notice that tvOS is still supported when integrating the library via Swift Package.

See also
https://github.com/wordpress-mobile/wpxmlrpc/pull/76#issuecomment-1885975334


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
