### PR TITLE
Configure Ruby Dependabot routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Ruby dependency surface
+Gemfile*              @wordpress-mobile/apps-infra-tooling
+.bundle/              @wordpress-mobile/apps-infra-tooling
+.rubocop*.yml         @wordpress-mobile/apps-infra-tooling
+fastlane/             @wordpress-mobile/apps-infra-tooling
+
+# CI and automation
+.buildkite/           @wordpress-mobile/apps-infra-tooling
+.github/dependabot.yml @wordpress-mobile/apps-infra-tooling
+
+# Toolchain and environment pins
+.ruby-version         @wordpress-mobile/apps-infra-tooling

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5


### PR DESCRIPTION
---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

## Summary

Configures daily Dependabot updates for Ruby dependencies and routes the Ruby/tooling/CI surface to `@wordpress-mobile/apps-infra-tooling` via CODEOWNERS. GitHub retired Dependabot's `reviewers` key, so routing now goes through CODEOWNERS.

## Testing

- Parsed `.github/dependabot.yml` and verified the campaign contract: one bundler entry, daily schedule, `ruby-minor-and-patch` grouping, open PR limit 5, and no `reviewers` key.
- Ran `git diff --check`.

Generated by Codex (GPT-5) on behalf of @mokagio.